### PR TITLE
feat: Update Client

### DIFF
--- a/src/ThirdPartyApi/Program.cs
+++ b/src/ThirdPartyApi/Program.cs
@@ -28,7 +28,6 @@ hostBuilder.ConfigureServices((context, services) =>
             config.PersonalAccessToken = thirdPartyApiConfiguration.PersonalAccessToken;
         },
         clientBuilder => clientBuilder.AddTransientHttpErrorPolicy(policy => policy
-            .OrResult(result => result.StatusCode != HttpStatusCode.ServiceUnavailable)
             .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(1), retryCount: 5))));
 
     services.AddTransient<IDemoService, ThirdPartyApiClientV1DemoService>();

--- a/src/ThirdPartyApi/ThirdPartyApi.csproj
+++ b/src/ThirdPartyApi/ThirdPartyApi.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Hsm.ClientService.ThirdPartyApi.Client" Version="1.0.0-alpha.0"/>
+        <PackageReference Include="Hsm.ClientService.ThirdPartyApi.Client" Version="1.0.0-alpha.1"/>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.2"/>
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1"/>


### PR DESCRIPTION
- remove `OrResult` which OR-ed the errorhandling and also retried Success and other statuscodes
- update `Hsm.ClientService.ThirdPartyApi.Client` to the latest version